### PR TITLE
fix: modify header to make JavBusUtil more stable.

### DIFF
--- a/jvav/utils.py
+++ b/jvav/utils.py
@@ -1043,8 +1043,13 @@ class JavBusUtil(BaseUtil):
     def get_headers(self):
         return {
             'authority': 'www.javbus.com',
+            'method': 'GET',
             'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'accept-encoding': 'gzip, deflate, br',
+            'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-US;q=0.7,fr-FR;q=0.6,fr;q=0.5',
             'cookie': f'bus_auth={self.bus_auth};',
+            'dnt': '1',
+            'sec-ch-ua-platform': '"Windows"',
             'user-agent': self.ua_desktop()
         }
 


### PR DESCRIPTION
* During my use, `JavBusUtil` has always been unstable. It always cannot accurately retrieve metainfo from web pages.
  * I modified the test case in [test.py](https://github.com/akynazh/jvav/blob/master/tests/test.py) and the results are as follows:
  ```log
  ============================= test session starts =============================
  collecting ... collected 1 item
  
  test.py::JavBusUtilTest::test_get_av_by_id PASSED                        [100%]{'id': 'mdyd-856', 'title': '', 'img': '', 'date': '', 'tags': '', 'stars': [], 'magnets': [], 'url': 'https://www.javbus.com/mdyd-856'}
  {'id': 'juq-280', 'title': '', 'img': '', 'date': '', 'tags': '', 'stars': [], 'magnets': [], 'url': 'https://www.javbus.com/juq-280'}
  {'id': 'dldss-265', 'title': '', 'img': '', 'date': '', 'tags': '', 'stars': [], 'magnets': [], 'url': 'https://www.javbus.com/dldss-265'}
  
  
  ======================== 1 passed, 4 warnings in 0.61s ========================
  ```
* I quickly discovered the reason: when we requested web content through `requests`, JavBus did not return the requested target information as expected, but instead returned an **Age Verification** page as follows:
  ![image](https://github.com/akynazh/jvav/assets/117360034/e2dac7e4-2422-427e-a2a5-b7972c38e6dc)
* But when I request web content through a browser, this page will not appear regardless of whether I am logged in or not. So I think the main reason is that when we request a website, the degree of "imitating the browser" is not enough. However, this issue is very simple. We only need to refine the current request header information to disguise it as a browser.
* The content I have committed is the smallest change I can approve. I tested several videos in this version and they all worked fine. But I don't think this solution can solve the problem once and for all. The **anti-crawling methods will always upgrade**, and perhaps this problem will still arise in the future, but at least it can be used for now.